### PR TITLE
Proposal to change left/right keys to be strafe instead of turn.

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -53,22 +53,12 @@ func keyboard_handling() {
 			player_pos_y = player_pos_y - player_delta_y
 		}
 		if ebiten.IsKeyPressed(ebiten.KeyLeft) || ebiten.IsKeyPressed(ebiten.KeyA) { // Q Azerty
-			player_angle -= 0.05
-			// Reset
-			if player_angle <= 0 {
-				player_angle = 6.283
-			}
-			player_delta_x = math.Cos(player_angle) * 5
-			player_delta_y = math.Sin(player_angle) * 5
+			player_pos_x = player_pos_x - player_strafe_delta_x
+			player_pos_y = player_pos_y - player_strafe_delta_y
 		}
 		if ebiten.IsKeyPressed(ebiten.KeyRight) || ebiten.IsKeyPressed(ebiten.KeyD) { // D
-			player_angle += 0.05
-			// Reset
-			if player_angle >= 6.283 {
-				player_angle = 0
-			}
-			player_delta_x = math.Cos(player_angle) * 5
-			player_delta_y = math.Sin(player_angle) * 5
+			player_pos_x = player_pos_x + player_strafe_delta_x
+			player_pos_y = player_pos_y + player_strafe_delta_y
 		}
 	}
 	if IsKeyTriggered(ebiten.KeyM) == true {

--- a/keyboard.go
+++ b/keyboard.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/hajimehoshi/ebiten/v2"
-	"math"
 	"os"
+
+	"github.com/hajimehoshi/ebiten/v2"
 )
 
 func keyboard_handling() {

--- a/ray_engine.go
+++ b/ray_engine.go
@@ -55,6 +55,8 @@ var (
 	player_pos_y      float64 = 50
 	player_delta_x    float64 = 0
 	player_delta_y    float64 = 0
+	player_strafe_delta_x	float64 = 0
+	player_strafe_delta_y float64 = 0
 	player_angle      float64 = 0
 	mapX              int     = 16
 	mapY              int     = 16
@@ -359,7 +361,10 @@ func (g *game) Draw(screen *ebiten.Image) {
 		if boot == 0 {
 			// Initial values for PDX/PDY, only applied once
 			player_delta_x = math.Cos(player_angle) * 2
-			player_delta_y = math.Sin(player_angle) * 2
+			player_delta_y = math.Sin(player_angle) * 2			
+			// Add 90 degrees in radians to get the right angle of player_angle
+			player_strafe_delta_x = math.Cos(player_angle+1.5708) * 2
+			player_strafe_delta_y = math.Sin(player_angle+1.5708) * 2
 		}
 	} else {
 		screen.DrawImage(backgroundImage, opBackground)
@@ -436,6 +441,9 @@ func (g *game) Draw(screen *ebiten.Image) {
 		player_angle = float64(x) / 360 // Breaks left/right on keyboard
 		player_delta_x = math.Cos(player_angle) * 2
 		player_delta_y = math.Sin(player_angle) * 2
+		// Add 90 degrees in radians to get the right angle of player_angle
+		player_strafe_delta_x = math.Cos(player_angle+1.5708) * 2
+		player_strafe_delta_y = math.Sin(player_angle+1.5708) * 2
 		// Mouse buttons
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 			// Ballistics

--- a/ray_engine.go
+++ b/ray_engine.go
@@ -363,8 +363,8 @@ func (g *game) Draw(screen *ebiten.Image) {
 			player_delta_x = math.Cos(player_angle) * 2
 			player_delta_y = math.Sin(player_angle) * 2
 			// Add 90 degrees in radians to get the right angle of player_angle
-			player_strafe_delta_x = math.Cos(player_angle+1.5708) * 2
-			player_strafe_delta_y = math.Sin(player_angle+1.5708) * 2
+			player_strafe_delta_x = math.Cos(player_angle+(math.Pi/2)) * 2
+			player_strafe_delta_y = math.Sin(player_angle+(math.Pi/2)) * 2
 		}
 	} else {
 		screen.DrawImage(backgroundImage, opBackground)
@@ -442,8 +442,8 @@ func (g *game) Draw(screen *ebiten.Image) {
 		player_delta_x = math.Cos(player_angle) * 2
 		player_delta_y = math.Sin(player_angle) * 2
 		// Add 90 degrees in radians to get the right angle of player_angle
-		player_strafe_delta_x = math.Cos(player_angle+1.5708) * 2
-		player_strafe_delta_y = math.Sin(player_angle+1.5708) * 2
+		player_strafe_delta_x = math.Cos(player_angle+(math.Pi/2)) * 2
+		player_strafe_delta_y = math.Sin(player_angle+(math.Pi/2)) * 2
 		// Mouse buttons
 		if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 			// Ballistics

--- a/ray_engine.go
+++ b/ray_engine.go
@@ -38,36 +38,36 @@ var (
 	wallEnemyImage      *ebiten.Image
 	gunImage            *ebiten.Image
 	//Enemy3DImage        *ebiten.Image
-	crossHairImage    *ebiten.Image
-	fireImage         *ebiten.Image
-	keyStates                 = map[ebiten.Key]int{}
-	bg_posx           float64 = 0
-	bg_posy           float64 = 0
-	wall_posx         float64 = 0
-	wall_posy         float64 = 0
-	wall_minimap_posx float64 = 20
-	wall_minimap_posy float64 = 350
-	CONST_PI          float64 = 3.1415926535
-	CONST_PI2         float64 = CONST_PI / 2
-	CONST_PI3         float64 = (3 * CONST_PI) / 2
-	CONST_DR          float64 = 0.0174533 // one radian in degrees
-	player_pos_x      float64 = 36
-	player_pos_y      float64 = 50
-	player_delta_x    float64 = 0
-	player_delta_y    float64 = 0
-	player_strafe_delta_x	float64 = 0
+	crossHairImage        *ebiten.Image
+	fireImage             *ebiten.Image
+	keyStates                     = map[ebiten.Key]int{}
+	bg_posx               float64 = 0
+	bg_posy               float64 = 0
+	wall_posx             float64 = 0
+	wall_posy             float64 = 0
+	wall_minimap_posx     float64 = 20
+	wall_minimap_posy     float64 = 350
+	CONST_PI              float64 = 3.1415926535
+	CONST_PI2             float64 = CONST_PI / 2
+	CONST_PI3             float64 = (3 * CONST_PI) / 2
+	CONST_DR              float64 = 0.0174533 // one radian in degrees
+	player_pos_x          float64 = 36
+	player_pos_y          float64 = 50
+	player_delta_x        float64 = 0
+	player_delta_y        float64 = 0
+	player_strafe_delta_x float64 = 0
 	player_strafe_delta_y float64 = 0
-	player_angle      float64 = 0
-	mapX              int     = 16
-	mapY              int     = 16
-	max_dof           int     = 16
-	boot                      = 42
-	mpv_run           []byte
-	engine_version    = "ray_engine 0.7.5"
-	debug_str         = "'Arrow : move, 'k' : exit, 'i' : debug info, 'l' : scanlines"
-	debug_str2        = "'m' : Gun mode/2D map mode, 'f' : fullscreen, j : toogle minimap"
-	str               string
-	map_array         = [256]int{
+	player_angle          float64 = 0
+	mapX                  int     = 16
+	mapY                  int     = 16
+	max_dof               int     = 16
+	boot                          = 42
+	mpv_run               []byte
+	engine_version        = "ray_engine 0.7.5"
+	debug_str             = "'Arrow : move, 'k' : exit, 'i' : debug info, 'l' : scanlines"
+	debug_str2            = "'m' : Gun mode/2D map mode, 'f' : fullscreen, j : toogle minimap"
+	str                   string
+	map_array             = [256]int{
 		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 		1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
 		1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
@@ -361,7 +361,7 @@ func (g *game) Draw(screen *ebiten.Image) {
 		if boot == 0 {
 			// Initial values for PDX/PDY, only applied once
 			player_delta_x = math.Cos(player_angle) * 2
-			player_delta_y = math.Sin(player_angle) * 2			
+			player_delta_y = math.Sin(player_angle) * 2
 			// Add 90 degrees in radians to get the right angle of player_angle
 			player_strafe_delta_x = math.Cos(player_angle+1.5708) * 2
 			player_strafe_delta_y = math.Sin(player_angle+1.5708) * 2


### PR DESCRIPTION
If the mouse is used to turn the player to the left or right, it makes more sense to change the left and right keys to strafe the player side to side instead. 

I've added `player_strafe_delta_x` and `player_strafe_delta_y` that calculate a delta similar to `player_delta_x` but with a 90 degree angle (1.5708 in radians) added on and use it on the appropriate key press.

The large block of edits is moving the variable definitions over by another tab to account for the longer variables.

If the goal is to have an entirely keyboard option similar to the original Doom, the period and comma keys could be used to turn the player left or right.